### PR TITLE
properly check for empty tag set

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,11 @@ impl Point {
             .into_iter()
             .map(Attr::Field)
             .collect();
-        let tag_str = format_attr(tag_attrs);
+        let tag_str = if tag_attrs.is_empty() {
+            None
+        } else {
+            Some(format_attr(tag_attrs))
+        };
         let field_str = format_attr(field_attrs);
         LineProtocol::new(self.measurement.clone(), tag_str, field_str)
     }
@@ -390,5 +394,19 @@ mod tests {
 
         let lp = p.to_lp();
         assert_eq!(lp.to_str(), "Foo,t1=v f1=10i,f2=10.3,f3=\"b\"\n");
+    }
+
+    #[test]
+    fn can_create_point_lp_no_tags() {
+        let p = Point::new(
+            String::from("Foo"),
+            vec![],
+            vec![
+                ("f1".to_owned(), Box::new(10)),
+                ("f2".to_owned(), Box::new(10.3)),
+            ]
+        );
+        let lp = p.to_lp();
+        assert_eq!(lp.to_str(), "Foo f1=10i,f2=10.3\n");
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -43,10 +43,13 @@ pub struct Field {
 impl LineProtocol {
     pub fn new(
         measurement: String,
-        tags: String,
+        tags: Option<String>,
         fields: String,
     ) -> Self {
-        Self(format!("{},{} {}\n", measurement, tags, fields))
+        match tags {
+            Some(t) => Self(format!("{},{} {}\n", measurement, t, fields)),
+            None => Self(format!("{} {}\n", measurement, fields))
+        }
     }
 
     pub fn to_str(&self) -> &str {


### PR DESCRIPTION
Properly account for the possibility of an empty tag set. Update LP conversion to correctly format when missing tag set.

Closes #4 