### PR TITLE
Unix domain socket support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ by InfluxData for making metrics reporting easy for distributed services - see t
 
 This library does not provide querying or other InfluxDB client-library features. This is meant to be lightweight and simple for services to report metrics.
 
+Telegraf-rust supports all socket connection types, such as UDS(unix domain socket):
+- TCP(`tcp://`)
+- UDP(`udp://`)
+- UDS Stream(`unix://`)
+- UDS Datagram(`unixgram://`)
+
 # Install
 
 Add it to your Cargo.toml:
@@ -26,7 +32,7 @@ Using this library assumes you have a socket listener setup in your Telegraf con
   service_address = "tcp://localhost:8094"
 ```
 
-All usage will start by creating a socket connection via a `Client`. This supports multiple connection protocols - which one you use will be determined by how your Telegraf `input.socket_listener` configuration is setup. Telegraf-rust supports both `TCP` and `UDP` socket connections.
+All usage will start by creating a socket connection via a `Client`. This supports multiple connection protocols - which one you use will be determined by how your Telegraf `input.socket_listener` configuration is setup. 
 
 Once a client is setup there are multiple different ways to write points:
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Any attribute that will be the value of a field must implement the `IntoFieldDat
 
 ```rust
 pub trait IntoFieldData {
-    fn into_field_data(&self) -> FieldData;
+    fn field_data(&self) -> FieldData;
 }
 ```
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -73,16 +73,14 @@ mod tests {
 
     #[test]
     fn can_create_with_tag() {
-        let p = point!("test", ("t", "v") ("t2", "v2"), ("f", "v"));
+        let p = point!("test", ("t", "v")("t2", "v2"), ("f", "v"));
         let exp = Point::new(
             "test".to_string(),
             vec![
                 ("t".to_string(), "v".to_string()),
                 ("t2".to_string(), "v2".to_string()),
             ],
-            vec![
-                ("f".to_string(), Box::new("v")),
-            ],
+            vec![("f".to_string(), Box::new("v"))],
         );
         assert_eq!(p, exp);
     }
@@ -93,9 +91,7 @@ mod tests {
         let exp = Point::new(
             "test".to_string(),
             Vec::new(),
-            vec![
-                ("f".to_string(), Box::new("v")),
-            ],
+            vec![("f".to_string(), Box::new("v"))],
         );
         assert_eq!(p, exp);
     }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -5,7 +5,7 @@ pub struct LineProtocol(String);
 /// Used to convert Rust types to influx types. Must be
 /// implemented by any type that will be used as a Field in a [crate::Point].
 pub trait IntoFieldData {
-    fn into_field_data(&self) -> FieldData;
+    fn field_data(&self) -> FieldData;
 }
 
 /// Influx types that can be used in a field.
@@ -23,32 +23,28 @@ pub enum FieldData {
 #[derive(Debug)]
 pub enum Attr {
     Tag(Tag),
-    Field(Field)
+    Field(Field),
 }
 
 /// Container struct for tag attributes.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Tag {
-    pub name:  String,
+    pub name: String,
     pub value: String,
 }
 
 /// Container struct for field attributes
 #[derive(Debug, Clone, PartialEq)]
 pub struct Field {
-    pub name:  String,
+    pub name: String,
     pub value: FieldData,
 }
 
 impl LineProtocol {
-    pub fn new(
-        measurement: String,
-        tags: Option<String>,
-        fields: String,
-    ) -> Self {
+    pub fn new(measurement: String, tags: Option<String>, fields: String) -> Self {
         match tags {
             Some(t) => Self(format!("{},{} {}\n", measurement, t, fields)),
-            None => Self(format!("{} {}\n", measurement, fields))
+            None => Self(format!("{} {}\n", measurement, fields)),
         }
     }
 
@@ -58,79 +54,79 @@ impl LineProtocol {
 }
 
 impl IntoFieldData for bool {
-    fn into_field_data(&self) -> FieldData {
+    fn field_data(&self) -> FieldData {
         FieldData::Boolean(*self)
     }
 }
 
 impl IntoFieldData for u8 {
-    fn into_field_data(&self) -> FieldData {
+    fn field_data(&self) -> FieldData {
         FieldData::UNumber(*self as u64)
     }
 }
 
 impl IntoFieldData for u16 {
-    fn into_field_data(&self) -> FieldData {
+    fn field_data(&self) -> FieldData {
         FieldData::UNumber(*self as u64)
     }
 }
 
 impl IntoFieldData for u32 {
-    fn into_field_data(&self) -> FieldData {
+    fn field_data(&self) -> FieldData {
         FieldData::UNumber(*self as u64)
     }
 }
 
 impl IntoFieldData for u64 {
-    fn into_field_data(&self) -> FieldData {
+    fn field_data(&self) -> FieldData {
         FieldData::UNumber(*self)
     }
 }
 
 impl IntoFieldData for i8 {
-    fn into_field_data(&self) -> FieldData {
+    fn field_data(&self) -> FieldData {
         FieldData::Number(*self as i64)
     }
 }
 
 impl IntoFieldData for i16 {
-    fn into_field_data(&self) -> FieldData {
+    fn field_data(&self) -> FieldData {
         FieldData::Number(*self as i64)
     }
 }
 
 impl IntoFieldData for i32 {
-    fn into_field_data(&self) -> FieldData {
+    fn field_data(&self) -> FieldData {
         FieldData::Number(*self as i64)
     }
 }
 
 impl IntoFieldData for i64 {
-    fn into_field_data(&self) -> FieldData {
+    fn field_data(&self) -> FieldData {
         FieldData::Number(*self)
     }
 }
 
 impl IntoFieldData for f32 {
-    fn into_field_data(&self) -> FieldData {
+    fn field_data(&self) -> FieldData {
         FieldData::Float(*self as f64)
     }
 }
 
 impl IntoFieldData for f64 {
-    fn into_field_data(&self) -> FieldData {
+    fn field_data(&self) -> FieldData {
         FieldData::Float(*self)
     }
 }
 
 impl IntoFieldData for &str {
-    fn into_field_data(&self) -> FieldData {
+    fn field_data(&self) -> FieldData {
         FieldData::Str(String::from(*self))
     }
 }
 
 impl IntoFieldData for String {
-    fn into_field_data(&self) -> FieldData {
+    fn field_data(&self) -> FieldData {
         FieldData::Str(self.to_string())
     }
 }
@@ -140,13 +136,14 @@ pub fn get_field_string(value: &FieldData) -> String {
         FieldData::Boolean(b) => format!("{}", b),
         FieldData::UNumber(n) => format!("{}u", n),
         FieldData::Number(n) => format!("{}i", n),
-        FieldData::Float(f)  => format!("{}", f),
-        FieldData::Str(s)    => format!(r#""{}""#, s)
+        FieldData::Float(f) => format!("{}", f),
+        FieldData::Str(s) => format!(r#""{}""#, s),
     }
 }
 
 pub fn format_attr(attrs: Vec<Attr>) -> String {
-    let mut out: Vec<String> = attrs.into_iter()
+    let mut out: Vec<String> = attrs
+        .into_iter()
         .map(|a| match a {
             Attr::Tag(t) => format!("{}={}", escape_spaces(&t.name), escape_spaces(&t.value)),
             Attr::Field(f) => format!("{}={}", escape_spaces(&f.name), get_field_string(&f.value)),
@@ -157,7 +154,7 @@ pub fn format_attr(attrs: Vec<Attr>) -> String {
 }
 
 fn escape_spaces(s: &str) -> String {
-    s.replace(" ", r#"\ "#)
+    s.replace(' ', r#"\ "#)
 }
 
 #[cfg(test)]
@@ -195,13 +192,25 @@ mod tests {
     #[test]
     fn can_format_field_attr() {
         let v1: Vec<Attr> = vec![
-            Attr::Field(Field { name: String::from("f1"), value: FieldData::Number(1) }),
-            Attr::Field(Field { name: String::from("f2"), value: FieldData::Number(2) })
+            Attr::Field(Field {
+                name: String::from("f1"),
+                value: FieldData::Number(1),
+            }),
+            Attr::Field(Field {
+                name: String::from("f2"),
+                value: FieldData::Number(2),
+            }),
         ];
 
         let v2: Vec<Attr> = vec![
-            Attr::Field(Field { name: String::from("f1"), value: FieldData::Number(1) }),
-            Attr::Field(Field { name: String::from("f2"), value: FieldData::Str(String::from("2")) })
+            Attr::Field(Field {
+                name: String::from("f1"),
+                value: FieldData::Number(1),
+            }),
+            Attr::Field(Field {
+                name: String::from("f2"),
+                value: FieldData::Str(String::from("2")),
+            }),
         ];
         assert_eq!(format_attr(v1), String::from("f1=1i,f2=2i"));
         assert_eq!(format_attr(v2), String::from("f1=1i,f2=\"2\""));

--- a/telegraf_derive/src/lib.rs
+++ b/telegraf_derive/src/lib.rs
@@ -1,7 +1,10 @@
 use proc_macro::TokenStream;
 use proc_macro2::{TokenStream as TStream2, TokenTree};
 use quote::quote;
-use syn::{Attribute, Data, DeriveInput, Fields, GenericParam, Generics, parse_macro_input, parse_quote, Type, Path};
+use syn::{
+    parse_macro_input, parse_quote, Attribute, Data, DeriveInput, Fields, GenericParam, Generics,
+    Path, Type,
+};
 
 fn krate() -> TStream2 {
     quote!(::telegraf)
@@ -39,20 +42,21 @@ fn expand_metric(tokens: TokenStream) -> TokenStream {
 
 fn get_measurement_name(input: &DeriveInput) -> TStream2 {
     let default = &input.ident;
-    let measurement = input.attrs.iter().filter(|a| {
-        a.path.segments.len() == 1
-            && a.path.segments[0].ident == "measurement"
-    }).nth(0);
+    let measurement = input
+        .attrs
+        .iter()
+        .find(|a| a.path.segments.len() == 1 && a.path.segments[0].ident == "measurement");
 
     match measurement {
         Some(attr) => {
-            let q = attr.tokens
+            let q = attr
+                .tokens
                 .clone()
                 .into_iter()
                 .nth(1)
                 .map(|t| match t {
                     TokenTree::Literal(l) => l,
-                    _ => panic!("unexpected type")
+                    _ => panic!("unexpected type"),
                 })
                 .unwrap();
             quote!(#q.to_string())
@@ -88,7 +92,7 @@ fn check_attr(t_tree: TokenTree, cmp: &str) -> bool {
             .into_iter()
             .next()
             .map(|token_tree| match token_tree {
-                TokenTree::Ident(ident) => ident.to_string() == cmp,
+                TokenTree::Ident(ident) => ident == cmp,
                 _ => false,
             })
             .unwrap(),

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -60,8 +60,13 @@ mod tests {
 
     #[test]
     fn can_derive_with_tags() {
-        let s = Tags { i: 1, t: "t".to_string(), f: 2., t2: 1. };
-        let exp = point!("Tags", ("t", "t") ("t2", 1.), ("i", 1) ("f", 2.));
+        let s = Tags {
+            i: 1,
+            t: "t".to_string(),
+            f: 2.,
+            t2: 1.,
+        };
+        let exp = point!("Tags", ("t", "t")("t2", 1.), ("i", 1)("f", 2.));
         assert_eq!(s.to_point(), exp);
     }
 
@@ -81,11 +86,17 @@ mod tests {
 
     #[test]
     fn can_derive_with_optionals() {
-        let s = Optionals { i: Some(1), t: Some("t".into()) };
+        let s = Optionals {
+            i: Some(1),
+            t: Some("t".into()),
+        };
         let exp = point!("Optionals", ("t", "t"), ("i", 1));
         assert_eq!(s.to_point(), exp);
 
-        let s = Optionals { i: Some(1), t: None };
+        let s = Optionals {
+            i: Some(1),
+            t: None,
+        };
         let exp = point!("Optionals", ("i", 1));
         assert_eq!(s.to_point(), exp);
     }


### PR DESCRIPTION
The current version only supports `TCP` and `UDP`, and the code currently fails to pass `cargo fmt -- --check` and `cargo clippy -- -D warnings`. I have followed the instructions of`fmt` and `clippy` and adjusted the code style to pass the cargo lint tool's checking. And added the support of `unix`(unix domain stream) and `unixgram`(unix domain datagram) two protocols, they can work normally after testing.