### PR TITLE
Add standalone derive example

### DIFF
--- a/examples/derive.rs
+++ b/examples/derive.rs
@@ -1,0 +1,29 @@
+use telegraf::Metric;
+
+#[derive(Metric)]
+struct Http {
+    /// Time in microseconds
+    latency: u64,
+    /// API method name (e.g. "users")
+    #[telegraf(tag)]
+    method: String,
+    /// HTTP status code
+    #[telegraf(tag)]
+    http_status: u16,
+}
+
+fn main() {
+    let point = Http {
+        latency: 123,
+        method: "users".to_string(),
+        http_status: 200,
+    };
+
+    let serialized = point.to_point();
+
+    assert_eq!(
+        serialized.to_string(),
+        "Http,http_status=200,method=users latency=123u\n"
+    );
+    println!("{}", serialized)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,6 +449,12 @@ impl<T> TelegrafUnwrap<T> for Option<T> {
     }
 }
 
+impl fmt::Display for Point {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_lp().to_str())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
### Description
Since it's a serialization library, an example of how to use it to produce `String` is important.
`serde_json` has this:
```rust
    // Some data structure.
    let address = Address {
        street: "10 Downing Street".to_owned(),
        city: "London".to_owned(),
    };

    // Serialize it to a JSON string.
    let j = serde_json::to_string(&address)?;

    // Print, write to a file, or send to an HTTP server.
    println!("{}", j);
```

This PR adds such an example. As a bonus, this crate can now be used without `Client` for anything, that implements `std::io::Write`.

### Related Issues
No previous issues reported.

### Checklist
- [ ] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] This is a documentation
