### PR TITLE
Remove `Client` and `Connector`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,4 @@ categories = ["database"]
 members = ["telegraf_derive", "tests"]
 
 [dependencies]
-url = "2.1.1"
 telegraf_derive = "0.2.0"


### PR DESCRIPTION
### Description
This crate contains unnecessary containers for various types of sockets. 
They may be removed to reduce the SLoC since the sending logic is pretty easy to implement. 
As bonus, `url` dependency may be removed.

Different network options may be expressed in examples, like the one I've added this week:
```rust
let telegraf = UdpSocket::bind("0.0.0.0:0")?;
telegraf.connect("localhost:8094")?;
telegraf.set_nonblocking(true)?;

telegraf.send(query_stat.to_point().to_string().as_bytes())?;
```

As another bonus: telegraf connection is easier to share. `Client` is not `Copy` and is `mut` !

Minus 200 LoC as result.

What do you think about such changes?

### Related Issues
This a new issue/proposal.

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
### Checklist (my)
- [ ] fix code is docs
- [ ] Add changelog?
